### PR TITLE
Dependency determination and ctags issues

### DIFF
--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -21,9 +21,3 @@ default['vim']['source']['version']       = '7.4'
 default['vim']['source']['checksum']      = '607e135c559be642f210094ad023dc65'
 default['vim']['source']['prefix']        = "/usr/local"
 default['vim']['source']['configuration'] = "--without-x --enable-pythoninterp --enable-rubyinterp --enable-cscope  --with-features=huge --prefix=#{default['vim']['source']['prefix']}"
-
-if platform_family? "rhel"
-  default['vim']['source']['dependencies']  = %w{ python-devel ncurses ncurses-devel ruby ruby-devel perl-devel ctags gcc make }
-else
-  default['vim']['source']['dependencies']  = %w{ python-dev libncurses5-dev ruby ruby-dev libperl-dev ctags gcc make }
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,5 @@
 name             "vim"
+depends          "apt::default"
 maintainer       "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -20,6 +20,12 @@
 cache_path            = Chef::Config['file_cache_path']
 source_version        = node['vim']['source']['version']
 
+if platform_family? "rhel"
+  node.default['vim']['source']['dependencies']  = %w{ python-devel ncurses ncurses-devel ruby ruby-devel perl-devel ctags gcc make }
+else
+  node.default['vim']['source']['dependencies']  = %w{ python-dev libncurses5-dev ruby ruby-dev libperl-dev ctags gcc make }
+end
+
 node['vim']['source']['dependencies'].each do |dependency|
   package dependency do
     action :install

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -35,6 +35,7 @@ end
 remote_file "#{cache_path}/vim-#{source_version}.tar.bz2" do
   source "http://ftp.vim.org/pub/vim/unix/vim-#{source_version}.tar.bz2"
   checksum node['vim']['source']['checksum']
+  action :create_if_missing
   notifies :run, "bash[install_vim]", :immediately
 end
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -23,7 +23,7 @@ source_version        = node['vim']['source']['version']
 if platform_family? "rhel"
   node.default['vim']['source']['dependencies']  = %w{ python-devel ncurses ncurses-devel ruby ruby-devel perl-devel ctags gcc make }
 else
-  node.default['vim']['source']['dependencies']  = %w{ python-dev libncurses5-dev ruby ruby-dev libperl-dev ctags gcc make }
+  node.default['vim']['source']['dependencies']  = %w{ python-dev libncurses5-dev ruby ruby-dev libperl-dev exuberant-ctags gcc make }
 end
 
 node['vim']['source']['dependencies'].each do |dependency|

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -24,6 +24,7 @@ if platform_family? "rhel"
   node.default['vim']['source']['dependencies']  = %w{ python-devel ncurses ncurses-devel ruby ruby-devel perl-devel ctags gcc make }
 else
   node.default['vim']['source']['dependencies']  = %w{ python-dev libncurses5-dev ruby ruby-dev libperl-dev exuberant-ctags gcc make }
+  include_recipe "apt::default" # run apt-get update before installing packages
 end
 
 node['vim']['source']['dependencies'].each do |dependency|


### PR DESCRIPTION
Ran into two issues attempting to install vim from source on a `hashicorp/precise64` Ubuntu box.

1. Dependencies attribute was not being determined correctly in the attributes file.

```
==> default: [2014-06-25T10:15:56+00:00] FATAL: Chef::Exceptions::Package: package[python-devel] (vim::source line 24) had an error: Chef::Exceptions::Package: No version specified, and no candidate version available for python-devel`
```

2. Installing ctags.

```
==> default: [2014-06-25T10:21:15+00:00] FATAL: Chef::Exceptions::Package: package[ctags] (vim::source line 30) had an error: Chef::Exceptions::Package: ctags is a virtual package provided by 2 packages, you must explicitly select one to install
```
