### PR TITLE
fix: migrate to Policyfile and clean up docs

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'apt'
-  cookbook 'homebrew'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'vim'
+
+default_source :supermarket
+
+run_list 'recipe[vim::default]'
+
+cookbook 'vim', path: '.'
+cookbook 'apt'
+cookbook 'homebrew'
+
+named_run_list :package, 'recipe[vim::default]'
+named_run_list :source, 'recipe[vim::default]'

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you would rather compile vim from source, as the case may be for centos nodes
 
 **Copyright:** 2008-2016, Chef Software, Inc.
 
-```
+```text
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -98,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  policyfile: Policyfile.rb
   deprecations_as_errors: true
 
 verifier:
@@ -28,9 +29,11 @@ platforms:
 
 suites:
   - name: package
+    named_run_list: package
     run_list:
       - recipe[vim::default]
   - name: source
+    named_run_list: source
     excludes:
       - macosx-10.12
     run_list:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- replace Berksfile/Berkshelf usage with Policyfile resolution
- wire Kitchen suites to Policyfile named run lists
- update Copilot setup to use chef install Policyfile.rb
- mark the README license block as text so markdownlint passes

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH_SYSTEM= /opt/chef-workstation/embedded/bin/rspec --format documentation
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list

Kitchen note: local Dokken is currently returning Excon socket errors for existing instances, so no converge result is claimed here.